### PR TITLE
fix "VersionCopy task adds extra c:" on windows #2

### DIFF
--- a/tasks/version_copy_bower_components.js
+++ b/tasks/version_copy_bower_components.js
@@ -27,9 +27,12 @@ module.exports = function(grunt) {
           return;
       }
 
+      //for windows
+      var canonicaldir = dependency.canonicalDir.split('\\').join('/');
+
       var componentData = {};
       componentData['version'] = pkgMeta.version;
-      componentData['directory'] = dependency.canonicalDir;
+      componentData['directory'] = canonicaldir;
       components[pkgMeta.name] = componentData;
 
       grunt.log.debug(key + " - version: " + componentData['version'] + " directory: " + componentData['directory']);


### PR DESCRIPTION
windows use \ as separator -> file.replace(srcDirectory, '') to remove part of the path in copyBowerComponent failed because
file : c:/<path_to_workspace/.../app/bower_components/..."
srcDirectory : c:\<path_to_workspace\...\app\bower_components\..."